### PR TITLE
Text grids for filter demonstration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@ __pycache__
 
 # VS code stuff
 .vscode
+
+# scratch files
+scratch
+
+# output files
+output
+
+# notebook checkpoints
+**/.ipynb_checkpoints/

--- a/notebooks/textgrid_demo.ipynb
+++ b/notebooks/textgrid_demo.ipynb
@@ -1,106 +1,211 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# textgrid demo (pytomofilt submodule)\n",
-        "\n",
-        "This notebook demonstrates the `pytomofilt.textgrid` submodule (formerly `mantletext`).\n",
-        "\n",
-        "It generates a regular lon/lat grid whose `z` values encode text in Robinson projection space.\n",
-        "\n",
-        "Notes:\n",
-        "- If `font_path=None`, the default DejaVu font may be downloaded on first use and cached.\n",
-        "- To force offline behavior, set `PYTOMOFILT_TEXTGRID_DISABLE_FONT_DOWNLOAD=1` or pass `font_path=...`.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from dataclasses import asdict\n",
-        "\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "import cartopy.crs as ccrs\n",
-        "\n",
-        "from pytomofilt.textgrid import TextGridConfig, generate_text_grid, save_grid_to_xyz_file\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "config = TextGridConfig(\n",
-        "    text=\"HELLO\",\n",
-        "    center_lon=0.0,\n",
-        "    center_lat=0.0,\n",
-        "    size_deg=60.0,\n",
-        "    central_meridian=0.0,\n",
-        "    grid_spacing_deg=1.0,\n",
-        "    font_size=160,\n",
-        ")\n",
-        "\n",
-        "df = generate_text_grid(config)\n",
-        "df.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Reshape to 2D for plotting\n",
-        "lons = np.sort(df[\"lon\"].unique())\n",
-        "lats = np.sort(df[\"lat\"].unique())\n",
-        "\n",
-        "# df is produced by meshgrid ravel; rebuild in that same order\n",
-        "z = df[\"z\"].to_numpy().reshape(len(lats), len(lons))\n",
-        "\n",
-        "crs_plot = ccrs.Robinson(central_longitude=config.central_meridian)\n",
-        "crs_data = ccrs.PlateCarree()\n",
-        "\n",
-        "fig = plt.figure(figsize=(11, 5))\n",
-        "ax = plt.axes(projection=crs_plot)\n",
-        "ax.set_global()\n",
-        "ax.coastlines(linewidth=0.6)\n",
-        "pc = ax.pcolormesh(lons, lats, z, transform=crs_data, cmap=\"Greys\", shading=\"auto\")\n",
-        "ax.set_title(\"textgrid mask (Robinson)\")\n",
-        "plt.colorbar(pc, ax=ax, shrink=0.75, pad=0.03, label=\"z\")\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Save as an xyz grid (git-ignored output folder)\n",
-        "out_path = \"output/textgrid_demo/hello.xyz\"\n",
-        "save_grid_to_xyz_file(df, out_path, config_dict=asdict(config))\n",
-        "out_path"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": ""
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo: create text grids \n",
+    "\n",
+    "Generate a regular lat/lon grid where **z = 1** (black) or **z = 0** (white), such that when plotted with a Robinson projection the user's text appears undistorted, for use in filtering tests\n",
+    "\n",
+    "## Setup"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import sys, pathlib\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import cartopy.crs as ccrs\n",
+    "from dataclasses import asdict\n",
+    "\n",
+    "from pytomofilt.textgrid import TextGridConfig, generate_text_grid, generate_multi_text_grid, save_grid_to_xyz_file, load_grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the plotting helper function\n",
+    "\n",
+    "A simple comparison plot of a Cartesian (Plat Caree) vs Robinson projection,  to demonstrate that the text is undistorted in Robinson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def plot_grid(df, central_meridian, title_extra=\"\"):\n",
+    "    \"\"\"Plot the grid in both Plate Carrée and Robinson projections.\"\"\"\n",
+    "    # Reshape z back to a 2-D grid\n",
+    "    lons = np.sort(df[\"lon\"].unique())\n",
+    "    lats = np.sort(df[\"lat\"].unique())\n",
+    "    z = df.set_index([\"lat\", \"lon\"])[\"z\"].unstack().values\n",
+    "\n",
+    "    fig, axes = plt.subplots(\n",
+    "        1, 2, figsize=(18, 6),\n",
+    "        subplot_kw={\"projection\": None},  # overridden below\n",
+    "    )\n",
+    "    plt.subplots_adjust(wspace=0.05)\n",
+    "\n",
+    "    projections = [\n",
+    "        ccrs.PlateCarree(),\n",
+    "        ccrs.Robinson(central_longitude=central_meridian),\n",
+    "    ]\n",
+    "    titles = [\n",
+    "        f\"Plate Carrée {title_extra}\",\n",
+    "        f\"Robinson {title_extra}\",\n",
+    "    ]\n",
+    "\n",
+    "    for ax_placeholder, proj, title in zip(axes, projections, titles):\n",
+    "        # Replace the non-geo axis with a geo one\n",
+    "        pos = ax_placeholder.get_position()\n",
+    "        ax_placeholder.remove()\n",
+    "        ax = fig.add_axes(pos, projection=proj)\n",
+    "\n",
+    "        ax.pcolormesh(\n",
+    "            lons, lats, z,\n",
+    "            transform=ccrs.PlateCarree(),\n",
+    "            cmap=\"Greys\",\n",
+    "            shading=\"auto\",\n",
+    "        )\n",
+    "        ax.coastlines(linewidth=0.5, color=\"steelblue\")\n",
+    "        ax.set_global()\n",
+    "        ax.set_title(title, fontsize=12)\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Step 1: layers with a single text object\n",
+    "\n",
+    "Iterate over depth slices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "words_dict = {\n",
+    "    50: [\"THE\", 135],\n",
+    "    660: [\"EARTH'S\", 270],\n",
+    "    1000: [\"LOWER\", 270],\n",
+    "    1500: [\"MANTLE\", 270],\n",
+    "    2000: [\"ROCKS\", 270],\n",
+    "}\n",
+    "\n",
+    "# Loop over the layers\n",
+    "for k, v in words_dict.items():\n",
+    "\n",
+    "    config = TextGridConfig(\n",
+    "        text             = v[0],\n",
+    "        center_lon       = 135.0,       # centre longitude of text placement (degrees)\n",
+    "        center_lat       = 0.0,         # centre latitude of text placement (degrees)\n",
+    "        size_deg         = v[1],        # width of text bounding box in degrees of longitude\n",
+    "        central_meridian = 135.0,       # Robinson projection central meridian (degrees)\n",
+    "        grid_spacing_deg = 0.5,         # output grid spacing (degrees)\n",
+    "        font_path        = None,        # None = auto-download DejaVu Sans Bold\n",
+    "        font_size        = 1000,        # font rasterisation quality (pixels)\n",
+    "        fill_value       = 1,           # Amount to add to the grid inside the text        \n",
+    "    )\n",
+    "\n",
+    "    # generate a pandas dataframe of the x y z values\n",
+    "    df = generate_text_grid(config)\n",
+    "\n",
+    "    # save the grid to disk in the output folder\n",
+    "    output_path = f\"output/depth_{k}.xyz\"\n",
+    "    save_grid_to_xyz_file(df, output_path)\n",
+    "\n",
+    "    # make a visualisation\n",
+    "    plot_grid(df, config.central_meridian, title_extra=f\"{k} km\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Step 2: CMB layer with two text objects\n",
+    "\n",
+    "Use the generate_multi_text_grid function to combine multiple TextGridConfig objects.\n",
+    "\n",
+    "Behaviour is that fill value is additive - such that if two text objects with fill value = 1 overlap, the result at the overlapping location will be 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "heart1 = TextGridConfig(\n",
+    "    text             = \"♥\",\n",
+    "    center_lon       = 10,\n",
+    "    center_lat       = -15,\n",
+    "    size_deg         = 60,\n",
+    "    central_meridian = 135.0,\n",
+    "    grid_spacing_deg = 0.5,\n",
+    "    font_path        = None,\n",
+    "    font_size        = 1000,\n",
+    "    fill_value       = 1\n",
+    ")\n",
+    "\n",
+    "heart2 = TextGridConfig(\n",
+    "    text             = \"♥\",\n",
+    "    center_lon       = -150,\n",
+    "    center_lat       = -15,\n",
+    "    size_deg         = 60,\n",
+    "    central_meridian = 135.0,\n",
+    "    grid_spacing_deg = 0.5,\n",
+    "    font_path        = None,\n",
+    "    font_size        = 1000,\n",
+    ")\n",
+    "\n",
+    "df = generate_multi_text_grid([heart1, heart2])\n",
+    "output_path = f\"output/depth_2850.xyz\"\n",
+    "save_grid_to_xyz_file(df, output_path)\n",
+    "plot_grid(df, config.central_meridian, title_extra=f\"2850 km\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }
-

--- a/notebooks/textgrid_demo.ipynb
+++ b/notebooks/textgrid_demo.ipynb
@@ -1,0 +1,106 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# textgrid demo (pytomofilt submodule)\n",
+        "\n",
+        "This notebook demonstrates the `pytomofilt.textgrid` submodule (formerly `mantletext`).\n",
+        "\n",
+        "It generates a regular lon/lat grid whose `z` values encode text in Robinson projection space.\n",
+        "\n",
+        "Notes:\n",
+        "- If `font_path=None`, the default DejaVu font may be downloaded on first use and cached.\n",
+        "- To force offline behavior, set `PYTOMOFILT_TEXTGRID_DISABLE_FONT_DOWNLOAD=1` or pass `font_path=...`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from dataclasses import asdict\n",
+        "\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import cartopy.crs as ccrs\n",
+        "\n",
+        "from pytomofilt.textgrid import TextGridConfig, generate_text_grid, save_grid_to_xyz_file\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "config = TextGridConfig(\n",
+        "    text=\"HELLO\",\n",
+        "    center_lon=0.0,\n",
+        "    center_lat=0.0,\n",
+        "    size_deg=60.0,\n",
+        "    central_meridian=0.0,\n",
+        "    grid_spacing_deg=1.0,\n",
+        "    font_size=160,\n",
+        ")\n",
+        "\n",
+        "df = generate_text_grid(config)\n",
+        "df.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Reshape to 2D for plotting\n",
+        "lons = np.sort(df[\"lon\"].unique())\n",
+        "lats = np.sort(df[\"lat\"].unique())\n",
+        "\n",
+        "# df is produced by meshgrid ravel; rebuild in that same order\n",
+        "z = df[\"z\"].to_numpy().reshape(len(lats), len(lons))\n",
+        "\n",
+        "crs_plot = ccrs.Robinson(central_longitude=config.central_meridian)\n",
+        "crs_data = ccrs.PlateCarree()\n",
+        "\n",
+        "fig = plt.figure(figsize=(11, 5))\n",
+        "ax = plt.axes(projection=crs_plot)\n",
+        "ax.set_global()\n",
+        "ax.coastlines(linewidth=0.6)\n",
+        "pc = ax.pcolormesh(lons, lats, z, transform=crs_data, cmap=\"Greys\", shading=\"auto\")\n",
+        "ax.set_title(\"textgrid mask (Robinson)\")\n",
+        "plt.colorbar(pc, ax=ax, shrink=0.75, pad=0.03, label=\"z\")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Save as an xyz grid (git-ignored output folder)\n",
+        "out_path = \"output/textgrid_demo/hello.xyz\"\n",
+        "save_grid_to_xyz_file(df, out_path, config_dict=asdict(config))\n",
+        "out_path"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": ""
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
   requires = ['setuptools>=61.0.0']
   build-backend = 'setuptools.build_meta'
 
-[tool.setuptools]
-  packages = ["pytomofilt"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pytomofilt*"]
 
 [project]
   name = "pytomofilt"
@@ -23,11 +24,26 @@
     "Environment :: Console",
     "Intended Audience :: Science/Research",
   ]
-  dependencies = ["pyshtools", "cartopy", "terratools", "numba", "scipy", "numpy", "typer", "typing_extensions"]
+  dependencies = [
+    "numpy",
+    "scipy",
+    "numba",
+    "pyshtools",
+    "terratools",
+    "cartopy",
+    "pandas",
+    "pyproj",
+    "pillow",
+    "requests",
+    "platformdirs",
+    "typer",
+    "typing_extensions",
+  ]
 
   [project.optional-dependencies]
     test = ["pytest", "pytest-cov"]
     docs = ["sphinx==7.1.2", "sphinx-rtd-theme==1.3.0rc1"]
+    demo = ["matplotlib", "jupyterlab", "ipykernel"]
 
   [project.scripts]
   ptf_reparam_filter_files = "pytomofilt.cli:app"

--- a/pytomofilt/textgrid/README.md
+++ b/pytomofilt/textgrid/README.md
@@ -1,0 +1,40 @@
+# `pytomofilt.textgrid`
+
+Generate regular lon/lat grids where `z` encodes rendered text in Robinson projection space.
+
+## Quick start
+
+```python
+from dataclasses import asdict
+
+from pytomofilt.textgrid import TextGridConfig, generate_text_grid, save_grid_to_xyz_file
+
+cfg = TextGridConfig(
+    text="HELLO",
+    center_lon=0.0,
+    center_lat=0.0,
+    size_deg=60.0,
+    central_meridian=0.0,
+    grid_spacing_deg=1.0,
+    font_size=160,
+)
+
+df = generate_text_grid(cfg)  # columns: lon, lat, z
+save_grid_to_xyz_file(df, "output/textgrid/hello.xyz", config_dict=asdict(cfg))
+```
+
+## Dependencies
+
+- **Core**: `numpy`, `pandas`, `pyproj`, `pillow`
+- **Default font download**: `requests`, `platformdirs`
+
+## Font behavior
+
+If `font_path=None`, `textgrid` will download the open-source **DejaVu Sans Bold** font on first use and cache it under your user cache directory.
+
+To force offline behavior, set:
+
+`PYTOMOFILT_TEXTGRID_DISABLE_FONT_DOWNLOAD=1`
+
+In that mode, `render_text_mask(..., font_path=None)` falls back to Pillow’s built-in default font (or you can pass an explicit `font_path` to a local `.ttf`).
+

--- a/pytomofilt/textgrid/__init__.py
+++ b/pytomofilt/textgrid/__init__.py
@@ -1,0 +1,22 @@
+"""
+textgrid — Generate lat/lon grids that render text in Robinson projection.
+"""
+
+from .projection import forward, inverse, get_robinson_transformer
+from .text_renderer import render_text_mask, get_default_font_path
+from .grid_generator import TextGridConfig, generate_text_grid, generate_multi_text_grid
+from .io_utils import save_grid, save_grid_to_xyz_file, load_grid
+
+__all__ = [
+    "forward",
+    "inverse",
+    "get_robinson_transformer",
+    "render_text_mask",
+    "get_default_font_path",
+    "TextGridConfig",
+    "generate_text_grid",
+    "generate_multi_text_grid",
+    "save_grid",
+    "save_grid_to_xyz_file",
+    "load_grid",
+]

--- a/pytomofilt/textgrid/grid_generator.py
+++ b/pytomofilt/textgrid/grid_generator.py
@@ -1,0 +1,171 @@
+"""
+Build a regular lat/lon grid and sample a text mask in Robinson projection space.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from . import projection
+from . import text_renderer
+
+
+@dataclass
+class TextGridConfig:
+    """
+    Configuration for text-grid generation.
+
+    Parameters
+    ----------
+    text : str
+        The text string to embed in the grid.
+    center_lon : float
+        Longitude (degrees) of the centre of the text placement.
+    center_lat : float
+        Latitude (degrees) of the centre of the text placement.
+    size_deg : float
+        Width of the text bounding box in degrees of longitude. The height
+        is derived automatically from the aspect ratio of the rendered text.
+    central_meridian : float
+        Central meridian of the Robinson projection (degrees). When data
+        is plotted with this central meridian the text will appear undistorted.
+    grid_spacing_deg : float
+        Grid spacing in degrees for both longitude and latitude.
+    font_path : str, Path or None
+        Path to a ``.ttf`` font file. ``None`` = auto-download an open-source font.
+    font_size : int
+        Font size passed to the text renderer (controls rasterisation quality).
+    fill_value : float
+        The z-value assigned to grid points that fall inside the rendered
+        text. Points outside the text remain 0. Default is ``1.0``.
+    """
+
+    text: str = "HELLO"
+    center_lon: float = 0.0
+    center_lat: float = 0.0
+    size_deg: float = 60.0
+    central_meridian: float = 0.0
+    grid_spacing_deg: float = 1.0
+    font_path: Optional[str] = None
+    font_size: int = 200
+    fill_value: float = 1.0
+
+
+def generate_text_grid(config: TextGridConfig) -> pd.DataFrame:
+    """
+    Generate a lat/lon/z grid where z encodes text in Robinson projection space.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``lon``, ``lat``, ``z``.
+    """
+    mask = text_renderer.render_text_mask(
+        config.text,
+        font_path=config.font_path,
+        font_size=config.font_size,
+    )
+    mask_h, mask_w = mask.shape
+
+    cx, cy = projection.forward(config.center_lon, config.center_lat, config.central_meridian)
+
+    left_lon = config.center_lon - config.size_deg / 2
+    right_lon = config.center_lon + config.size_deg / 2
+    x_left, _ = projection.forward(left_lon, config.center_lat, config.central_meridian)
+    x_right, _ = projection.forward(right_lon, config.center_lat, config.central_meridian)
+    bbox_width_m = abs(x_right - x_left)
+
+    aspect = mask_h / mask_w
+    bbox_height_m = bbox_width_m * aspect
+
+    x_min = cx - bbox_width_m / 2
+    y_max = cy + bbox_height_m / 2
+
+    lons = np.arange(-180, 180, config.grid_spacing_deg)
+    lats = np.arange(-90, 90 + config.grid_spacing_deg / 2, config.grid_spacing_deg)
+    lats = lats[lats <= 90]
+
+    lon_grid, lat_grid = np.meshgrid(lons, lats)
+    lon_flat = lon_grid.ravel()
+    lat_flat = lat_grid.ravel()
+
+    x_all, y_all = projection.forward(lon_flat, lat_flat, config.central_meridian)
+
+    z = np.zeros(len(lon_flat), dtype=np.float64)
+
+    px = ((x_all - x_min) / bbox_width_m * mask_w).astype(np.float64)
+    py = ((y_max - y_all) / bbox_height_m * mask_h).astype(np.float64)
+
+    ix = np.floor(px).astype(np.int64)
+    iy = np.floor(py).astype(np.int64)
+
+    inside = (ix >= 0) & (ix < mask_w) & (iy >= 0) & (iy < mask_h)
+    z[inside] = np.where(mask[iy[inside], ix[inside]], config.fill_value, 0.0)
+
+    return pd.DataFrame({"lon": lon_flat, "lat": lat_flat, "z": z})
+
+
+def _sample_text_to_z(config: TextGridConfig, lon_flat: np.ndarray, lat_flat: np.ndarray) -> np.ndarray:
+    mask = text_renderer.render_text_mask(
+        config.text,
+        font_path=config.font_path,
+        font_size=config.font_size,
+    )
+    mask_h, mask_w = mask.shape
+
+    cx, cy = projection.forward(config.center_lon, config.center_lat, config.central_meridian)
+
+    left_lon = config.center_lon - config.size_deg / 2
+    right_lon = config.center_lon + config.size_deg / 2
+    x_left, _ = projection.forward(left_lon, config.center_lat, config.central_meridian)
+    x_right, _ = projection.forward(right_lon, config.center_lat, config.central_meridian)
+    bbox_width_m = abs(x_right - x_left)
+
+    aspect = mask_h / mask_w
+    bbox_height_m = bbox_width_m * aspect
+
+    x_min = cx - bbox_width_m / 2
+    y_max = cy + bbox_height_m / 2
+
+    x_all, y_all = projection.forward(lon_flat, lat_flat, config.central_meridian)
+
+    z = np.zeros(len(lon_flat), dtype=np.float64)
+
+    px = ((x_all - x_min) / bbox_width_m * mask_w).astype(np.float64)
+    py = ((y_max - y_all) / bbox_height_m * mask_h).astype(np.float64)
+
+    ix = np.floor(px).astype(np.int64)
+    iy = np.floor(py).astype(np.int64)
+
+    inside = (ix >= 0) & (ix < mask_w) & (iy >= 0) & (iy < mask_h)
+    z[inside] = np.where(mask[iy[inside], ix[inside]], config.fill_value, 0.0)
+    return z
+
+
+def generate_multi_text_grid(configs: list[TextGridConfig]) -> pd.DataFrame:
+    """
+    Generate a single lat/lon/z grid with multiple text objects composited.
+
+    Where multiple texts overlap, their fill values are added.
+    """
+    if not configs:
+        raise ValueError("configs must contain at least one TextGridConfig")
+
+    spacing = configs[0].grid_spacing_deg
+
+    lons = np.arange(-180, 180, spacing)
+    lats = np.arange(-90, 90 + spacing / 2, spacing)
+    lats = lats[lats <= 90]
+
+    lon_grid, lat_grid = np.meshgrid(lons, lats)
+    lon_flat = lon_grid.ravel()
+    lat_flat = lat_grid.ravel()
+
+    z_total = np.zeros(len(lon_flat), dtype=np.float64)
+    for cfg in configs:
+        z_total += _sample_text_to_z(cfg, lon_flat, lat_flat)
+
+    return pd.DataFrame({"lon": lon_flat, "lat": lat_flat, "z": z_total})
+

--- a/pytomofilt/textgrid/io_utils.py
+++ b/pytomofilt/textgrid/io_utils.py
@@ -1,0 +1,105 @@
+"""
+Read / write lat-lon-z grid files.
+"""
+
+import json
+import pathlib
+from typing import Optional
+
+import pandas as pd
+
+
+def save_grid(
+    df: pd.DataFrame,
+    filepath: str | pathlib.Path,
+    config_dict: Optional[dict] = None,
+) -> pathlib.Path:
+    """
+    Save a lon/lat/z DataFrame to a CSV text file.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Must contain columns ``lon``, ``lat``, ``z``.
+    filepath : str or Path
+        Destination file path.
+    config_dict : dict, optional
+        Generation parameters to store in a ``#``-prefixed JSON header line.
+
+    Returns
+    -------
+    pathlib.Path
+        The written file path.
+    """
+    filepath = pathlib.Path(filepath)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(filepath, "w", newline="") as f:
+        if config_dict is not None:
+            f.write(f"# {json.dumps(config_dict)}\n")
+        df.to_csv(f, index=False)
+
+    return filepath
+
+
+def save_grid_to_xyz_file(
+    df: pd.DataFrame,
+    filepath: str | pathlib.Path,
+    config_dict: Optional[dict] = None,
+) -> pathlib.Path:
+    """
+    Save a lon/lat/z DataFrame to a tab-separated xyz text file.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Must contain columns ``lon``, ``lat``, ``z``.
+    filepath : str or Path
+        Destination file path.
+    config_dict : dict, optional
+        Generation parameters to store in a ``#``-prefixed JSON header line.
+
+    Returns
+    -------
+    pathlib.Path
+        The written file path.
+    """
+    filepath = pathlib.Path(filepath)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(filepath, "w", newline="") as f:
+        if config_dict is not None:
+            f.write(f"# {json.dumps(config_dict)}\n")
+        df.to_csv(f, index=False, sep="\t")
+
+    return filepath
+
+
+def load_grid(filepath: str | pathlib.Path) -> tuple[pd.DataFrame, Optional[dict]]:
+    """
+    Load a previously saved grid file.
+
+    Parameters
+    ----------
+    filepath : str or Path
+
+    Returns
+    -------
+    df : pd.DataFrame
+        Columns ``lon``, ``lat``, ``z``.
+    config : dict or None
+        The config dict from the header, if present.
+    """
+    filepath = pathlib.Path(filepath)
+    config = None
+
+    with open(filepath, "r") as f:
+        first_line = f.readline()
+        if first_line.startswith("# "):
+            try:
+                config = json.loads(first_line[2:])
+            except json.JSONDecodeError:
+                config = None
+
+    df = pd.read_csv(filepath, comment="#")
+    return df, config

--- a/pytomofilt/textgrid/projection.py
+++ b/pytomofilt/textgrid/projection.py
@@ -1,0 +1,77 @@
+"""
+Robinson projection helpers using pyproj.
+"""
+
+import numpy as np
+from pyproj import Transformer
+
+
+def get_robinson_transformer(central_lon: float = 0.0, direction: str = "forward"):
+    """
+    Return a pyproj Transformer for the Robinson projection.
+
+    Parameters
+    ----------
+    central_lon : float
+        Central meridian of the Robinson projection in degrees.
+    direction : str
+        ``"forward"`` for lon/lat → x/y, ``"inverse"`` for x/y → lon/lat.
+
+    Returns
+    -------
+    pyproj.Transformer
+    """
+    proj_string = (
+        f"+proj=robin +lon_0={central_lon} +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"
+    )
+    if direction == "forward":
+        return Transformer.from_proj("EPSG:4326", proj_string, always_xy=True)
+    if direction == "inverse":
+        return Transformer.from_proj(proj_string, "EPSG:4326", always_xy=True)
+    raise ValueError(f"direction must be 'forward' or 'inverse', got '{direction}'")
+
+
+def forward(lon, lat, central_lon: float = 0.0):
+    """
+    Project longitude / latitude → Robinson x, y (metres).
+
+    Parameters
+    ----------
+    lon, lat : float or array-like
+        Geographic coordinates in degrees.
+    central_lon : float
+        Central meridian of the Robinson projection.
+
+    Returns
+    -------
+    x, y : ndarray
+        Projected coordinates in metres.
+    """
+    transformer = get_robinson_transformer(central_lon, direction="forward")
+    lon = np.asarray(lon, dtype=np.float64)
+    lat = np.asarray(lat, dtype=np.float64)
+    x, y = transformer.transform(lon, lat)
+    return np.asarray(x), np.asarray(y)
+
+
+def inverse(x, y, central_lon: float = 0.0):
+    """
+    Inverse-project Robinson x, y (metres) → longitude, latitude.
+
+    Parameters
+    ----------
+    x, y : float or array-like
+        Projected coordinates in metres.
+    central_lon : float
+        Central meridian of the Robinson projection.
+
+    Returns
+    -------
+    lon, lat : ndarray
+        Geographic coordinates in degrees.
+    """
+    transformer = get_robinson_transformer(central_lon, direction="inverse")
+    x = np.asarray(x, dtype=np.float64)
+    y = np.asarray(y, dtype=np.float64)
+    lon, lat = transformer.transform(x, y)
+    return np.asarray(lon), np.asarray(lat)

--- a/pytomofilt/textgrid/text_renderer.py
+++ b/pytomofilt/textgrid/text_renderer.py
@@ -1,0 +1,114 @@
+"""
+Render a text string to a binary numpy mask using Pillow.
+
+If no font path is supplied, an open-source TTF (DejaVu Sans) is
+automatically downloaded and cached.
+"""
+
+import os
+import pathlib
+
+import numpy as np
+import requests
+from platformdirs import user_cache_dir
+from PIL import Image, ImageDraw, ImageFont
+
+_DISABLE_FONT_DOWNLOAD_ENV = "PYTOMOFILT_TEXTGRID_DISABLE_FONT_DOWNLOAD"
+
+
+def _is_truthy_env(name: str) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return False
+    return val.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+# User-writable cache directory for downloaded font(s)
+_FONT_CACHE_DIR = pathlib.Path(user_cache_dir("pytomofilt", appauthor=False)) / "textgrid"
+
+_DEFAULT_FONT_URL = (
+    "https://github.com/dejavu-fonts/dejavu-fonts/releases/download/"
+    "version_2_37/dejavu-fonts-ttf-2.37.zip"
+)
+_DEFAULT_FONT_FILENAME = "DejaVuSans-Bold.ttf"
+
+
+def get_default_font_path() -> pathlib.Path:
+    """
+    Return the path to a cached open-source TTF font file.
+
+    Downloads DejaVu Sans Bold from GitHub on first use and caches it.
+    """
+    if _is_truthy_env(_DISABLE_FONT_DOWNLOAD_ENV):
+        raise RuntimeError(
+            "Default font download is disabled. Provide `font_path=...` or unset "
+            f"{_DISABLE_FONT_DOWNLOAD_ENV}."
+        )
+
+    cached = _FONT_CACHE_DIR / _DEFAULT_FONT_FILENAME
+    if cached.exists():
+        return cached
+
+    _FONT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"Downloading default font from {_DEFAULT_FONT_URL} ...")
+    import io
+    import zipfile
+
+    resp = requests.get(_DEFAULT_FONT_URL, timeout=60)
+    resp.raise_for_status()
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        for name in zf.namelist():
+            if name.endswith(_DEFAULT_FONT_FILENAME):
+                data = zf.read(name)
+                tmp = cached.with_suffix(cached.suffix + ".tmp")
+                tmp.write_bytes(data)
+                tmp.replace(cached)
+                print(f"Font cached at {cached}")
+                return cached
+
+    raise RuntimeError(f"Could not find {_DEFAULT_FONT_FILENAME} in downloaded archive.")
+
+
+def render_text_mask(
+    text: str,
+    font_path: str | os.PathLike | None = None,
+    font_size: int = 100,
+) -> np.ndarray:
+    """
+    Render *text* to a tight-cropped binary numpy mask.
+
+    Returns
+    -------
+    mask : ndarray of bool
+        2-D array where ``True`` = text foreground, ``False`` = background.
+    """
+    if not text:
+        raise ValueError("text must be a non-empty string")
+
+    font = None
+    if font_path is None:
+        try:
+            font_path = get_default_font_path()
+            font = ImageFont.truetype(str(font_path), font_size)
+        except RuntimeError:
+            font = ImageFont.load_default()
+    else:
+        font = ImageFont.truetype(str(font_path), font_size)
+
+    dummy = Image.new("1", (1, 1), color=0)
+    draw = ImageDraw.Draw(dummy)
+    bbox = draw.textbbox((0, 0), text, font=font)
+    text_w = bbox[2] - bbox[0]
+    text_h = bbox[3] - bbox[1]
+
+    if text_w <= 0 or text_h <= 0:
+        raise ValueError(f"Text '{text}' rendered with zero size.")
+
+    img = Image.new("1", (text_w, text_h), color=1)
+    draw = ImageDraw.Draw(img)
+    draw.text((-bbox[0], -bbox[1]), text, fill=0, font=font)
+
+    arr = np.array(img, dtype=bool)
+    return ~arr
+

--- a/tests/test_textgrid_grid_generator.py
+++ b/tests/test_textgrid_grid_generator.py
@@ -1,0 +1,134 @@
+"""Tests for pytomofilt.textgrid.grid_generator."""
+
+import numpy as np
+import pytest
+
+from pytomofilt.textgrid import TextGridConfig, generate_multi_text_grid, generate_text_grid
+
+
+class TestGenerateTextGrid:
+    @pytest.fixture
+    def default_config(self):
+        return TextGridConfig(
+            text="X",
+            center_lon=0.0,
+            center_lat=0.0,
+            size_deg=30.0,
+            central_meridian=0.0,
+            grid_spacing_deg=5.0,
+            font_size=100,
+        )
+
+    def test_output_columns(self, default_config):
+        df = generate_text_grid(default_config)
+        assert list(df.columns) == ["lon", "lat", "z"]
+
+    def test_z_values_default(self, default_config):
+        df = generate_text_grid(default_config)
+        unique = set(df["z"].unique())
+        assert unique.issubset({0.0, 1.0})
+
+    def test_has_nonzero_z(self, default_config):
+        df = generate_text_grid(default_config)
+        assert (df["z"] != 0).any(), "Grid should contain some non-zero z for 'X'"
+
+    def test_grid_spacing(self, default_config):
+        df = generate_text_grid(default_config)
+        lons = np.sort(df["lon"].unique())
+        diffs = np.diff(lons)
+        np.testing.assert_allclose(diffs, default_config.grid_spacing_deg, atol=1e-10)
+
+    def test_different_central_meridian(self):
+        config = TextGridConfig(
+            text="T",
+            center_lon=90.0,
+            center_lat=0.0,
+            size_deg=30.0,
+            central_meridian=90.0,
+            grid_spacing_deg=5.0,
+            font_size=100,
+        )
+        df = generate_text_grid(config)
+        assert (df["z"] != 0).any()
+
+    def test_custom_fill_value(self):
+        config = TextGridConfig(
+            text="X",
+            center_lon=0.0,
+            center_lat=0.0,
+            size_deg=30.0,
+            central_meridian=0.0,
+            grid_spacing_deg=5.0,
+            font_size=100,
+            fill_value=42.0,
+        )
+        df = generate_text_grid(config)
+        nonzero = df.loc[df["z"] != 0, "z"]
+        assert len(nonzero) > 0
+        assert (nonzero == 42.0).all()
+
+
+class TestGenerateMultiTextGrid:
+    def test_basic_output_columns(self):
+        configs = [
+            TextGridConfig(
+                text="A",
+                center_lon=-60.0,
+                center_lat=0.0,
+                size_deg=20.0,
+                grid_spacing_deg=5.0,
+                font_size=80,
+            )
+        ]
+        df = generate_multi_text_grid(configs)
+        assert list(df.columns) == ["lon", "lat", "z"]
+
+    def test_two_texts_non_overlapping(self):
+        c1 = TextGridConfig(
+            text="A",
+            center_lon=-60.0,
+            center_lat=30.0,
+            size_deg=20.0,
+            grid_spacing_deg=5.0,
+            font_size=80,
+            fill_value=10.0,
+        )
+        c2 = TextGridConfig(
+            text="B",
+            center_lon=60.0,
+            center_lat=-30.0,
+            size_deg=20.0,
+            grid_spacing_deg=5.0,
+            font_size=80,
+            fill_value=20.0,
+        )
+        df = generate_multi_text_grid([c1, c2])
+        assert (df["z"] == 10.0).any(), "First text should produce z=10"
+        assert (df["z"] == 20.0).any(), "Second text should produce z=20"
+
+    def test_additive_overlap(self):
+        c1 = TextGridConfig(
+            text="X",
+            center_lon=0.0,
+            center_lat=0.0,
+            size_deg=30.0,
+            grid_spacing_deg=5.0,
+            font_size=100,
+            fill_value=5.0,
+        )
+        c2 = TextGridConfig(
+            text="X",
+            center_lon=0.0,
+            center_lat=0.0,
+            size_deg=30.0,
+            grid_spacing_deg=5.0,
+            font_size=100,
+            fill_value=3.0,
+        )
+        df = generate_multi_text_grid([c1, c2])
+        assert (df["z"] == 8.0).any(), "Overlapping text should produce additive z=8.0"
+
+    def test_empty_configs_raises(self):
+        with pytest.raises(ValueError):
+            generate_multi_text_grid([])
+

--- a/tests/test_textgrid_io_utils.py
+++ b/tests/test_textgrid_io_utils.py
@@ -1,0 +1,40 @@
+"""Tests for pytomofilt.textgrid.io_utils."""
+
+import pandas as pd
+
+from pytomofilt.textgrid.io_utils import load_grid, save_grid
+
+
+class TestSaveLoadRoundTrip:
+    def _make_df(self):
+        return pd.DataFrame(
+            {
+                "lon": [0.0, 1.0, 2.0],
+                "lat": [10.0, 20.0, 30.0],
+                "z": [0, 1, 0],
+            }
+        )
+
+    def test_roundtrip(self, tmp_path):
+        df = self._make_df()
+        fpath = tmp_path / "grid.csv"
+        save_grid(df, fpath)
+        df2, cfg = load_grid(fpath)
+        pd.testing.assert_frame_equal(df, df2)
+        assert cfg is None
+
+    def test_roundtrip_with_config(self, tmp_path):
+        df = self._make_df()
+        fpath = tmp_path / "grid.csv"
+        config = {"text": "HI", "size_deg": 30.0}
+        save_grid(df, fpath, config_dict=config)
+        df2, cfg = load_grid(fpath)
+        pd.testing.assert_frame_equal(df, df2)
+        assert cfg == config
+
+    def test_creates_parent_dirs(self, tmp_path):
+        df = self._make_df()
+        fpath = tmp_path / "sub" / "dir" / "grid.csv"
+        save_grid(df, fpath)
+        assert fpath.exists()
+

--- a/tests/test_textgrid_projection.py
+++ b/tests/test_textgrid_projection.py
@@ -1,0 +1,48 @@
+"""Tests for pytomofilt.textgrid.projection."""
+
+import numpy as np
+import pytest
+
+from pytomofilt.textgrid.projection import forward, get_robinson_transformer, inverse
+
+
+class TestForwardInverseRoundTrip:
+    @pytest.mark.parametrize("central_lon", [0.0, 90.0, -120.0, 180.0])
+    def test_roundtrip_scalar(self, central_lon):
+        lon, lat = 30.0, 45.0
+        x, y = forward(lon, lat, central_lon)
+        lon2, lat2 = inverse(x, y, central_lon)
+        assert abs(lon2 - lon) < 1e-6
+        assert abs(lat2 - lat) < 1e-6
+
+    def test_roundtrip_array(self):
+        lons = np.array([-179, -90, 0, 90, 179])
+        lats = np.array([-60, -30, 0, 30, 60])
+        x, y = forward(lons, lats, 0.0)
+        lon2, lat2 = inverse(x, y, 0.0)
+        np.testing.assert_allclose(lon2, lons, atol=1e-4)
+        np.testing.assert_allclose(lat2, lats, atol=1e-4)
+
+
+class TestEdgeCases:
+    def test_equator_origin(self):
+        x, y = forward(0.0, 0.0, 0.0)
+        assert abs(x) < 1e-3
+        assert abs(y) < 1e-3
+
+    def test_north_pole(self):
+        x, y = forward(0.0, 90.0, 0.0)
+        assert abs(x) < 1e-3
+        assert y > 0
+
+    def test_south_pole(self):
+        x, y = forward(0.0, -90.0, 0.0)
+        assert abs(x) < 1e-3
+        assert y < 0
+
+
+class TestTransformerFactory:
+    def test_invalid_direction(self):
+        with pytest.raises(ValueError):
+            get_robinson_transformer(0, direction="sideways")
+

--- a/tests/test_textgrid_text_renderer.py
+++ b/tests/test_textgrid_text_renderer.py
@@ -1,0 +1,46 @@
+"""Tests for pytomofilt.textgrid.text_renderer."""
+
+import pytest
+
+from pytomofilt.textgrid.text_renderer import get_default_font_path, render_text_mask
+
+
+@pytest.fixture(autouse=True)
+def _disable_font_download(monkeypatch):
+    monkeypatch.setenv("PYTOMOFILT_TEXTGRID_DISABLE_FONT_DOWNLOAD", "1")
+
+
+class TestRenderTextMask:
+    def test_basic_shape(self):
+        mask = render_text_mask("A", font_size=50)
+        assert mask.ndim == 2
+        assert mask.shape[0] > 0
+        assert mask.shape[1] > 0
+
+    def test_dtype_is_bool(self):
+        mask = render_text_mask("Hi", font_size=50)
+        assert mask.dtype == bool
+
+    def test_contains_foreground(self):
+        mask = render_text_mask("X", font_size=80)
+        assert mask.any(), "Mask should contain at least one True pixel"
+
+    def test_contains_background(self):
+        mask = render_text_mask("I", font_size=80)
+        assert not mask.all(), "Mask should contain some False pixels"
+
+    def test_wider_for_longer_text(self):
+        mask_short = render_text_mask("A", font_size=80)
+        mask_long = render_text_mask("ABCDEF", font_size=80)
+        assert mask_long.shape[1] > mask_short.shape[1]
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError):
+            render_text_mask("")
+
+
+class TestGetDefaultFontPath:
+    def test_disabled_download_raises(self):
+        with pytest.raises(RuntimeError):
+            get_default_font_path()
+


### PR DESCRIPTION
Functionality to create "Text Grids" - xyz formatted ASCII files containing Lon / Lat / Z value which when projected into a Robinson projection appear as rendered text.

- New submodule `textgrid` containing the code required to render Robinson projection
- Added a notebooks directory at the top level of the repo
- Tests integrated
- pyproject.toml updated to reflect new dependencies
- minor tweaks to .gitignore, to exclude outputs and notebook checkpoints

<img width="720" height="981" alt="image" src="https://github.com/user-attachments/assets/8ea2d9ee-9090-4bff-a114-3d663f503bab" />
<img width="720" height="199" alt="image" src="https://github.com/user-attachments/assets/77a1eef3-458a-43c7-a652-b029bfcb2faf" />
